### PR TITLE
Initialize session state in all subpages and set German as default language

### DIFF
--- a/Dashboard.py
+++ b/Dashboard.py
@@ -35,6 +35,10 @@ from src.prediction_pipeline.modeling.create_inference_dfs import visitor_predic
 from src.prediction_pipeline.modeling.source_and_feature_selection import get_features
 from src.prediction_pipeline.modeling.train_regressor import train_regressor
 
+# Initialize language in session state if it doesn't exist
+if 'selected_language' not in st.session_state:
+    st.session_state.selected_language = 'German'  # Default language
+
 # Set the page layout - it is a two column layout
 col1, col2 = page_layout_config.get_page_layout()
 

--- a/pages/Admin_🔓.py
+++ b/pages/Admin_🔓.py
@@ -6,6 +6,10 @@ from src.streamlit_app.pages_in_dashboard.admin.parking import get_parking_secti
 from src.streamlit_app.source_data import source_and_preprocess_realtime_parking_data
 from src.streamlit_app.pages_in_dashboard.visitors.language_selection_menu import TRANSLATIONS
 
+# Initialize language in session state if it doesn't exist
+if 'selected_language' not in st.session_state:
+    st.session_state.selected_language = 'German'  # Default language
+
 # Title of the page - page layout
 st.write(f"# {TRANSLATIONS[st.session_state.selected_language]['admin_page_title']}")
 

--- a/pages/Data_Access_📊.py
+++ b/pages/Data_Access_📊.py
@@ -6,6 +6,10 @@ from src.streamlit_app.pages_in_dashboard.data_accessibility.upload import uploa
 from src.streamlit_app.pages_in_dashboard.data_accessibility.download import download_section
 from src.streamlit_app.pages_in_dashboard.admin.password import check_password
 
+# Initialize language in session state if it doesn't exist
+if 'selected_language' not in st.session_state:
+    st.session_state.selected_language = 'German'  # Default language
+
 # Define the page layout of the Streamlit app
 
 st.set_page_config(

--- a/src/streamlit_app/pages_in_dashboard/visitors/language_selection_menu.py
+++ b/src/streamlit_app/pages_in_dashboard/visitors/language_selection_menu.py
@@ -148,10 +148,6 @@ TRANSLATIONS = {
     }
 }
 
-# Initialize language in session state if it doesn't exist
-if 'selected_language' not in st.session_state:
-    st.session_state.selected_language = 'German'  # Default language
-
 def update_language():
     if st.session_state.selected_language == 'German':
         st.session_state.selected_language = 'English'


### PR DESCRIPTION
In the previous PR merge for the translation, the session_state for setting German as default language was not properly implemented. This PR fixes this.